### PR TITLE
Fix the strange recents Android P transition

### DIFF
--- a/config/compiled-classes-phone
+++ b/config/compiled-classes-phone
@@ -4747,6 +4747,7 @@ android.view.animation.AnimationUtils$1
 android.view.animation.AnimationUtils$AnimationState
 android.view.animation.BaseInterpolator
 android.view.animation.ClipRectAnimation
+android.view.animation.ClipRectAnimationF
 android.view.animation.CycleInterpolator
 android.view.animation.DecelerateInterpolator
 android.view.animation.GridLayoutAnimationController$AnimationParameters

--- a/core/java/android/view/animation/AnimationUtils.java
+++ b/core/java/android/view/animation/AnimationUtils.java
@@ -124,18 +124,18 @@ public class AnimationUtils {
         }
     }
 
-    private static Animation getActivityOpenEnterAnim(){
-      AnimationSet animationSet = new AnimationSet(false);
-      animationSet.setZAdjustment(Animation.ZORDER_TOP);
-      TranslateAnimation translateAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.04100001f, Animation.RELATIVE_TO_SELF, 0.0f);
-      translateAnimation.setInterpolator(fastOutSlowIn());
-      translateAnimation.setDuration(425L);
-      animationSet.addAnimation(translateAnimation);
-      ClipRectAnimation clipRectAnimation = new ClipRectAnimation(0.0f, 0.959f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f);
-      clipRectAnimation.setDuration(425L);
-      clipRectAnimation.setInterpolator(fastOutExtraSlowIn());
-      animationSet.addAnimation(clipRectAnimation);
-      return animationSet;
+    private static Animation getActivityOpenEnterAnim() {
+        AnimationSet animationSet = new AnimationSet(false);
+        animationSet.setZAdjustment(Animation.ZORDER_TOP);
+        TranslateAnimation translateAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.04100001f, Animation.RELATIVE_TO_SELF, 0.0f);
+        translateAnimation.setInterpolator(fastOutSlowIn());
+        translateAnimation.setDuration(425L);
+        animationSet.addAnimation(translateAnimation);
+        ClipRectAnimationF clipRectAnimationF = new ClipRectAnimationF(0.0f, 0.959f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f);
+        clipRectAnimationF.setDuration(425L);
+        clipRectAnimationF.setInterpolator(fastOutExtraSlowIn());
+        animationSet.addAnimation(clipRectAnimationF);
+        return animationSet;
     }
 
     private static Animation getActivityOpenExitAnim(){
@@ -166,16 +166,16 @@ public class AnimationUtils {
     }
 
     private static Animation getActivityCloseExitAnim(){
-      AnimationSet animationSet = new AnimationSet(false);
-      TranslateAnimation translateAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.04100001f);
-      translateAnimation.setDuration(425L);
-      translateAnimation.setInterpolator(fastOutSlowIn());
-      animationSet.addAnimation(translateAnimation);
-      ClipRectAnimation clipRectAnimation = new ClipRectAnimation(0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.959f, 1.0f, 1.0f);
-      clipRectAnimation.setDuration(425L);
-      clipRectAnimation.setInterpolator(fastOutExtraSlowIn());
-      animationSet.addAnimation(clipRectAnimation);
-      return animationSet;
+        AnimationSet animationSet = new AnimationSet(false);
+        TranslateAnimation translateAnimation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF, 0.04100001f);
+        translateAnimation.setDuration(425L);
+        translateAnimation.setInterpolator(fastOutSlowIn());
+        animationSet.addAnimation(translateAnimation);
+        ClipRectAnimationF clipRectAnimationF = new ClipRectAnimationF(0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.959f, 1.0f, 1.0f);
+        clipRectAnimationF.setDuration(425L);
+        clipRectAnimationF.setInterpolator(fastOutExtraSlowIn());
+        animationSet.addAnimation(clipRectAnimationF);
+        return animationSet;
     }
 
     private static Animation getTaskOpenEnterAnim(){

--- a/core/java/android/view/animation/ClipRectAnimation.java
+++ b/core/java/android/view/animation/ClipRectAnimation.java
@@ -17,7 +17,6 @@
 package android.view.animation;
 
 import android.graphics.Rect;
-import android.graphics.RectF;
 
 /**
  * An animation that controls the clip of an object. See the
@@ -27,12 +26,8 @@ import android.graphics.RectF;
  * @hide
  */
 public class ClipRectAnimation extends Animation {
-    protected RectF mFromRectF = new RectF();
-    protected RectF mToRectF = new RectF();
     protected Rect mFromRect = new Rect();
     protected Rect mToRect = new Rect();
-    protected Rect mResolvedFrom = new Rect();
-    protected Rect mResolvedTo = new Rect();
 
     /**
      * Constructor to use when building a ClipRectAnimation from code
@@ -55,35 +50,14 @@ public class ClipRectAnimation extends Animation {
             int toL, int toT, int toR, int toB) {
         mFromRect.set(fromL, fromT, fromR, fromB);
         mToRect.set(toL, toT, toR, toB);
-        mFromRectF.set(1.0f, 1.0f, 1.0f, 1.0f);
-        mToRectF.set(1.0f, 1.0f, 1.0f, 1.0f);
-    }
-
-    public ClipRectAnimation(float fromL, float fromT, float fromR, float fromB,
-                             float toL, float toT, float toR, float toB) {
-        mFromRectF.set(fromL, fromT, fromR, fromB);
-        mToRectF.set(toL, toT, toR, toB);
-    }
-
-    @Override
-    public void initialize(int width, int height, int parentWidth, int parentHeight) {
-        super.initialize(width, height, parentWidth, parentHeight);
-        mResolvedFrom.left = (int) resolveSize(RELATIVE_TO_SELF, mFromRectF.left, width, parentWidth);
-        mResolvedFrom.top = (int) resolveSize(RELATIVE_TO_SELF, mFromRectF.top, height, parentHeight);
-        mResolvedFrom.right = (int) resolveSize(RELATIVE_TO_SELF, mFromRectF.right, width, parentWidth);
-        mResolvedFrom.bottom = (int) resolveSize(RELATIVE_TO_SELF, mFromRectF.bottom, height, parentHeight);
-        mResolvedTo.left = (int) resolveSize(RELATIVE_TO_SELF, mToRectF.left, width, parentWidth);
-        mResolvedTo.top = (int) resolveSize(RELATIVE_TO_SELF, mToRectF.top, height, parentHeight);
-        mResolvedTo.right = (int) resolveSize(RELATIVE_TO_SELF, mToRectF.right, width, parentWidth);
-        mResolvedTo.bottom = (int) resolveSize(RELATIVE_TO_SELF, mToRectF.bottom, height, parentHeight);
     }
 
     @Override
     protected void applyTransformation(float it, Transformation tr) {
-        int l = mResolvedFrom.left + (int) ((mResolvedTo.left - mResolvedFrom.left) * it);
-        int t = mResolvedFrom.top + (int) ((mResolvedTo.top - mResolvedFrom.top) * it);
-        int r = mResolvedFrom.right + (int) ((mResolvedTo.right - mResolvedFrom.right) * it);
-        int b = mResolvedFrom.bottom + (int) ((mResolvedTo.bottom - mResolvedFrom.bottom) * it);
+        int l = mFromRect.left + (int) ((mToRect.left - mFromRect.left) * it);
+        int t = mFromRect.top + (int) ((mToRect.top - mFromRect.top) * it);
+        int r = mFromRect.right + (int) ((mToRect.right - mFromRect.right) * it);
+        int b = mFromRect.bottom + (int) ((mToRect.bottom - mFromRect.bottom) * it);
         tr.setClipRect(l, t, r, b);
     }
 

--- a/core/java/android/view/animation/ClipRectAnimationF.java
+++ b/core/java/android/view/animation/ClipRectAnimationF.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.view.animation;
+
+import android.graphics.Rect;
+import android.graphics.RectF;
+
+/**
+ * An animation that controls the clip of an object. See the
+ * {@link android.view.animation full package} description for details and
+ * sample code.
+ *
+ * @hide
+ */
+public class ClipRectAnimationF extends Animation {
+    protected RectF mFromRectF = new RectF();
+    protected RectF mToRectF = new RectF();
+    protected Rect mFromRect = new Rect();
+    protected Rect mToRect = new Rect();
+    protected Rect mResolvedFrom = new Rect();
+    protected Rect mResolvedTo = new Rect();
+
+    /**
+     * Constructor to use when building a ClipRectAnimationF from code
+     *
+     * @param fromClip the clip rect to animate from
+     * @param toClip the clip rect to animate to
+     */
+    public ClipRectAnimationF(Rect fromClip, Rect toClip) {
+        if (fromClip == null || toClip == null) {
+            throw new RuntimeException("Expected non-null animation clip rects");
+        }
+        mFromRect.set(fromClip);
+        mToRect.set(toClip);
+    }
+
+    /**
+     * Constructor to use when building a ClipRectAnimationF from code
+     */
+    public ClipRectAnimationF(int fromL, int fromT, int fromR, int fromB,
+            int toL, int toT, int toR, int toB) {
+        mFromRect.set(fromL, fromT, fromR, fromB);
+        mToRect.set(toL, toT, toR, toB);
+        mFromRectF.set(1.0f, 1.0f, 1.0f, 1.0f);
+        mToRectF.set(1.0f, 1.0f, 1.0f, 1.0f);
+    }
+
+    public ClipRectAnimationF(float fromL, float fromT, float fromR, float fromB,
+                             float toL, float toT, float toR, float toB) {
+        mFromRectF.set(fromL, fromT, fromR, fromB);
+        mToRectF.set(toL, toT, toR, toB);
+    }
+
+    @Override
+    public void initialize(int width, int height, int parentWidth, int parentHeight) {
+        super.initialize(width, height, parentWidth, parentHeight);
+        mResolvedFrom.left = (int) resolveSize(RELATIVE_TO_SELF, mFromRectF.left, width, parentWidth);
+        mResolvedFrom.top = (int) resolveSize(RELATIVE_TO_SELF, mFromRectF.top, height, parentHeight);
+        mResolvedFrom.right = (int) resolveSize(RELATIVE_TO_SELF, mFromRectF.right, width, parentWidth);
+        mResolvedFrom.bottom = (int) resolveSize(RELATIVE_TO_SELF, mFromRectF.bottom, height, parentHeight);
+        mResolvedTo.left = (int) resolveSize(RELATIVE_TO_SELF, mToRectF.left, width, parentWidth);
+        mResolvedTo.top = (int) resolveSize(RELATIVE_TO_SELF, mToRectF.top, height, parentHeight);
+        mResolvedTo.right = (int) resolveSize(RELATIVE_TO_SELF, mToRectF.right, width, parentWidth);
+        mResolvedTo.bottom = (int) resolveSize(RELATIVE_TO_SELF, mToRectF.bottom, height, parentHeight);
+    }
+
+    @Override
+    protected void applyTransformation(float it, Transformation tr) {
+        int l = mResolvedFrom.left + (int) ((mResolvedTo.left - mResolvedFrom.left) * it);
+        int t = mResolvedFrom.top + (int) ((mResolvedTo.top - mResolvedFrom.top) * it);
+        int r = mResolvedFrom.right + (int) ((mResolvedTo.right - mResolvedFrom.right) * it);
+        int b = mResolvedFrom.bottom + (int) ((mResolvedTo.bottom - mResolvedFrom.bottom) * it);
+        tr.setClipRect(l, t, r, b);
+    }
+
+    @Override
+    public boolean willChangeTransformationMatrix() {
+        return false;
+    }
+}


### PR DESCRIPTION
Because the default ClipRectAnimation class was modified.
For this reason, we should rename this class to ClipRectAnimationF,
which is only used by AnimationUtils.java and does not change
the original ClipRectAnimation class.

Change-Id: I5df709f08fb8c853be7a40aa2bd371ee9ca6083a
Signed-off-by: Shubham Singh <coolsks94@gmail.com>
Signed-off-by: Sebastian <xdzienny@gmail.com>